### PR TITLE
Add flexible LLM adapter pattern for easy provider switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,10 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Project-specific files
+.python-version
+main.py
+server_config.json
+papers/
+report.md

--- a/application/llm_adapter.py
+++ b/application/llm_adapter.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any, Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class ChatMessage:
+    role: str
+    content: Optional[str] = None
+    tool_calls: Optional[List[Any]] = None
+    tool_call_id: Optional[str] = None
+
+
+@dataclass
+class ChatResponse:
+    content: Optional[str]
+    tool_calls: Optional[List[Any]] = None
+    usage: Optional[Dict[str, int]] = None
+
+
+class LLMAdapter(ABC):
+    """Abstract base class for LLM adapters"""
+    
+    def __init__(self, model: str, **kwargs):
+        self.model = model
+        self.config = kwargs
+    
+    @abstractmethod
+    async def chat_completion(
+        self, 
+        messages: List[ChatMessage], 
+        tools: Optional[List[Dict]] = None,
+        max_tokens: int = 2048,
+        temperature: float = 0.7,
+        **kwargs
+    ) -> ChatResponse:
+        """Generate a chat completion"""
+        pass
+    
+    @abstractmethod
+    def get_available_models(self) -> List[str]:
+        """Get list of available models for this provider"""
+        pass
+    
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Name of the LLM provider"""
+        pass

--- a/application/llm_factory.py
+++ b/application/llm_factory.py
@@ -1,0 +1,56 @@
+from typing import Dict, Type
+from .llm_adapter import LLMAdapter
+from .openai_adapter import OpenAIAdapter, OpenRouterAdapter
+
+
+class LLMFactory:
+    """Factory for creating LLM adapters"""
+    
+    _adapters: Dict[str, Type[LLMAdapter]] = {
+        "openai": OpenAIAdapter,
+        "openrouter": OpenRouterAdapter,
+    }
+    
+    @classmethod
+    def create_adapter(cls, provider: str, model: str, **kwargs) -> LLMAdapter:
+        """Create an adapter instance"""
+        if provider not in cls._adapters:
+            raise ValueError(f"Unknown provider: {provider}. Available: {list(cls._adapters.keys())}")
+        
+        adapter_class = cls._adapters[provider]
+        return adapter_class(model=model, **kwargs)
+    
+    @classmethod
+    def register_adapter(cls, name: str, adapter_class: Type[LLMAdapter]):
+        """Register a new adapter type"""
+        cls._adapters[name] = adapter_class
+    
+    @classmethod
+    def get_available_providers(cls) -> list[str]:
+        """Get list of available providers"""
+        return list(cls._adapters.keys())
+
+
+# Predefined configurations for common setups
+LLM_CONFIGS = {
+    "gpt4o": {
+        "provider": "openrouter",
+        "model": "openai/gpt-4o",
+    },
+    "gpt4o-mini": {
+        "provider": "openrouter", 
+        "model": "openai/gpt-4o-mini",
+    },
+    "claude-sonnet": {
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-sonnet",
+    },
+    "claude-haiku": {
+        "provider": "openrouter",
+        "model": "anthropic/claude-3-haiku", 
+    },
+    "llama-70b": {
+        "provider": "openrouter",
+        "model": "meta-llama/llama-3-70b-instruct",
+    }
+}

--- a/application/openai_adapter.py
+++ b/application/openai_adapter.py
@@ -1,0 +1,92 @@
+import openai
+import os
+from typing import List, Dict, Any, Optional
+from .llm_adapter import LLMAdapter, ChatMessage, ChatResponse
+
+
+class OpenAIAdapter(LLMAdapter):
+    """OpenAI API adapter (works with OpenAI and OpenRouter)"""
+    
+    def __init__(self, model: str, api_key: Optional[str] = None, base_url: Optional[str] = None, **kwargs):
+        super().__init__(model, **kwargs)
+        
+        self.client = openai.OpenAI(
+            api_key=api_key or os.getenv("OPENAI_API_KEY"),
+            base_url=base_url,
+            **kwargs
+        )
+    
+    async def chat_completion(
+        self, 
+        messages: List[ChatMessage], 
+        tools: Optional[List[Dict]] = None,
+        max_tokens: int = 2048,
+        temperature: float = 0.7,
+        **kwargs
+    ) -> ChatResponse:
+        # Convert our ChatMessage format to OpenAI format
+        openai_messages = []
+        for msg in messages:
+            openai_msg = {"role": msg.role}
+            if msg.content:
+                openai_msg["content"] = msg.content
+            if msg.tool_calls:
+                openai_msg["tool_calls"] = msg.tool_calls
+            if msg.tool_call_id:
+                openai_msg["tool_call_id"] = msg.tool_call_id
+            openai_messages.append(openai_msg)
+        
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=openai_messages,
+            tools=tools,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            **kwargs
+        )
+        
+        choice = response.choices[0]
+        return ChatResponse(
+            content=choice.message.content,
+            tool_calls=choice.message.tool_calls,
+            usage=response.usage.model_dump() if response.usage else None
+        )
+    
+    def get_available_models(self) -> List[str]:
+        # This would ideally fetch from the API, but for now return common models
+        return [
+            "gpt-4o",
+            "gpt-4o-mini", 
+            "gpt-4-turbo",
+            "gpt-3.5-turbo"
+        ]
+    
+    @property
+    def provider_name(self) -> str:
+        return "OpenAI"
+
+
+class OpenRouterAdapter(OpenAIAdapter):
+    """OpenRouter adapter - extends OpenAI adapter with OpenRouter specifics"""
+    
+    def __init__(self, model: str, **kwargs):
+        super().__init__(
+            model=model,
+            api_key=os.getenv("OPENROUTER_API_KEY"),
+            base_url="https://openrouter.ai/api/v1",
+            **kwargs
+        )
+    
+    def get_available_models(self) -> List[str]:
+        return [
+            "openai/gpt-4o",
+            "openai/gpt-4o-mini",
+            "anthropic/claude-3-sonnet",
+            "anthropic/claude-3-haiku",
+            "meta-llama/llama-3-70b-instruct",
+            "google/gemini-pro"
+        ]
+    
+    @property
+    def provider_name(self) -> str:
+        return "OpenRouter"


### PR DESCRIPTION
- Create abstract LLMAdapter base class with standardized interface
- Implement OpenAI/OpenRouter adapters with tool calling support
- Add LLMFactory for easy adapter creation and provider management
- Refactor MCP_ChatBot to use adapter pattern instead of direct API calls
- Support predefined configs for popular models (GPT-4o, Claude, Llama)
- Enable seamless switching between different LLM providers
- Update .gitignore to exclude temporary and config files

🤖 Generated with [Claude Code](https://claude.ai/code)